### PR TITLE
remove hybrid collision detector

### DIFF
--- a/launch/chomp_planning_pipeline.launch.xml
+++ b/launch/chomp_planning_pipeline.launch.xml
@@ -1,15 +1,10 @@
 <launch>
-
    <!-- CHOMP Plugin for MoveIt! -->
    <arg name="planning_plugin" value="chomp_interface/CHOMPPlanner" />
-
    <arg name="start_state_max_bounds_error" value="0.1" />
 
    <param name="planning_plugin" value="$(arg planning_plugin)" />
    <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
-   <param name="collision_detector" value="Hybrid" />
-
    <rosparam command="load" file="$(find panda_moveit_config)/config/chomp_planning.yaml" />
-
 </launch>


### PR DESCRIPTION
As of https://github.com/ros-planning/moveit/pull/1251, CHOMP uses automatically the hybrid collision detector.