### PR TITLE
Fix incorrect SRDF path

### DIFF
--- a/.setup_assistant
+++ b/.setup_assistant
@@ -3,7 +3,7 @@ moveit_setup_assistant_config:
     package: franka_description
     relative_path: robots/panda_arm_hand.urdf.xacro
   SRDF:
-    relative_path: config/panda.srdf
+    relative_path: config/panda_arm.srdf.xacro
   CONFIG:
     author_name: Mike Lautman
     author_email: mike@picknik.ai


### PR DESCRIPTION
When I run the MSA it doesn't find the SRDF due to recent changes in Xacro