### PR TITLE
removing unused attempts param

### DIFF
--- a/config/kinematics.yaml
+++ b/config/kinematics.yaml
@@ -2,4 +2,3 @@ panda_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.05
-  kinematics_solver_attempts: 5


### PR DESCRIPTION
fixes this error:
```
ros.moveit_ros_planning.kinematics_plugin_loader: Kinematics solver doesn't support #attempts anymore, but only a timeout.
Please remove the parameter '/robot_description_kinematics/panda_arm/kinematics_solver_attempts' from your configuration.
```