### PR TITLE
demo.launch: expose planner arg

### DIFF
--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="planner" default="ompl" />
+
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
   <!-- Allow user to specify database location -->
@@ -39,6 +41,7 @@
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include file="$(find panda_moveit_config)/launch/move_group.launch">
+    <arg name="planner" value="$(arg planner)" />
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>


### PR DESCRIPTION
... facilitates switching between OMPL and CHOMP pipeline when using `demo.launch`.