### PR TITLE
Adapt pipelines

### DIFF
--- a/launch/chomp_planning_pipeline.launch.xml
+++ b/launch/chomp_planning_pipeline.launch.xml
@@ -4,6 +4,14 @@
    <arg name="start_state_max_bounds_error" value="0.1" />
 
    <param name="planning_plugin" value="$(arg planning_plugin)" />
+   <param name="request_adapters" value="
+       default_planner_request_adapters/FixWorkspaceBounds
+       default_planner_request_adapters/FixStartStateBounds
+       default_planner_request_adapters/FixStartStateCollision
+       default_planner_request_adapters/FixStartStatePathConstraints
+       default_planner_request_adapters/ResolveConstraintFrames
+       default_planner_request_adapters/AddTimeParameterization"
+       />
    <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
    <rosparam command="load" file="$(find panda_moveit_config)/config/chomp_planning.yaml" />

--- a/launch/ompl_planning_pipeline.launch.xml
+++ b/launch/ompl_planning_pipeline.launch.xml
@@ -5,12 +5,14 @@
 
   <!-- The request adapters (plugins) used when planning with OMPL. 
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
-				       default_planner_request_adapters/FixWorkspaceBounds
-				       default_planner_request_adapters/FixStartStateBounds
-				       default_planner_request_adapters/FixStartStateCollision
-				       default_planner_request_adapters/FixStartStatePathConstraints" />
-
+  <arg name="planning_adapters" value="
+       default_planner_request_adapters/FixWorkspaceBounds
+       default_planner_request_adapters/FixStartStateBounds
+       default_planner_request_adapters/FixStartStateCollision
+       default_planner_request_adapters/FixStartStatePathConstraints
+       default_planner_request_adapters/ResolveConstraintFrames
+       default_planner_request_adapters/AddTimeParameterization"
+       />
   <arg name="start_state_max_bounds_error" value="0.1" />
 
   <param name="planning_plugin" value="$(arg planning_plugin)" />


### PR DESCRIPTION
Correctly define (in case of CHOMP) or update planning request adapters to include new `default_planner_request_adapters/ResolveConstraintFrames`.
As the new adapter is only available in melodic, _now_ we need to branch off from kinetic.