### PR TITLE
[Windows][melodic-devel] Replaced single quotes usage with double quotes for portability

### DIFF
--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -8,8 +8,8 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(eval arg('load_robot_description') and arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
-  <param if="$(eval arg('load_robot_description') and not arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm.urdf.xacro'"/>
+  <param if="$(eval arg('load_robot_description') and arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder &quot;$(find franka_description)/robots/panda_arm_hand.urdf.xacro&quot;"/>
+  <param if="$(eval arg('load_robot_description') and not arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder &quot;$(find franka_description)/robots/panda_arm.urdf.xacro&quot;"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro --inorder '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" if="$(arg load_gripper)" />


### PR DESCRIPTION
On some platforms (e.g., Windows), the single quotes won't be escaped from the shell and it is applications' responsibility to interpret the characters. In such case, `xacro` will be seeing extra single quote from the argument line, try to open an invalid file path, and ends up errors.