### PR TITLE
Update SRDF for collision model

### DIFF
--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -40,6 +40,7 @@
     <disable_collisions link1="panda_link4" link2="panda_link8" reason="Never" />
     <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent" />
     <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent" />
+    <disable_collisions link1="panda_link6" link2="panda_link8" reason="Default" />
     <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent" />
   </xacro:macro>
 </robot>

--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -28,19 +28,18 @@
     <disable_collisions link1="panda_link0" link2="panda_link3" reason="Never" />
     <disable_collisions link1="panda_link0" link2="panda_link4" reason="Never" />
     <disable_collisions link1="panda_link1" link2="panda_link2" reason="Adjacent" />
-    <disable_collisions link1="panda_link1" link2="panda_link3" reason="Never" />
+    <disable_collisions link1="panda_link1" link2="panda_link3" reason="Default" />
     <disable_collisions link1="panda_link1" link2="panda_link4" reason="Never" />
     <disable_collisions link1="panda_link2" link2="panda_link3" reason="Adjacent" />
     <disable_collisions link1="panda_link2" link2="panda_link4" reason="Never" />
-    <disable_collisions link1="panda_link2" link2="panda_link6" reason="Never" />
     <disable_collisions link1="panda_link3" link2="panda_link4" reason="Adjacent" />
-    <disable_collisions link1="panda_link3" link2="panda_link5" reason="Never" />
     <disable_collisions link1="panda_link3" link2="panda_link6" reason="Never" />
-    <disable_collisions link1="panda_link3" link2="panda_link7" reason="Never" />
     <disable_collisions link1="panda_link4" link2="panda_link5" reason="Adjacent" />
     <disable_collisions link1="panda_link4" link2="panda_link6" reason="Never" />
     <disable_collisions link1="panda_link4" link2="panda_link7" reason="Never" />
+    <disable_collisions link1="panda_link4" link2="panda_link8" reason="Never" />
     <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent" />
     <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent" />
+    <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent" />
   </xacro:macro>
 </robot>

--- a/config/panda_arm_hand.srdf.xacro
+++ b/config/panda_arm_hand.srdf.xacro
@@ -38,16 +38,16 @@
   <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
   <end_effector name="hand" parent_link="panda_link8" group="hand" parent_group="panda_arm" />
   <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
-  <disable_collisions link1="panda_hand" link2="panda_link3" reason="Never" />
   <disable_collisions link1="panda_hand" link2="panda_link4" reason="Never" />
   <disable_collisions link1="panda_hand" link2="panda_link6" reason="Never" />
-  <disable_collisions link1="panda_hand" link2="panda_link7" reason="Adjacent" />
-  <disable_collisions link1="panda_leftfinger" link2="panda_link3" reason="Never" />
+  <disable_collisions link1="panda_hand" link2="panda_link7" reason="Default" />
+  <disable_collisions link1="panda_hand" link2="panda_link8" reason="Adjacent" />
   <disable_collisions link1="panda_leftfinger" link2="panda_link4" reason="Never" />
   <disable_collisions link1="panda_leftfinger" link2="panda_link6" reason="Never" />
   <disable_collisions link1="panda_leftfinger" link2="panda_link7" reason="Never" />
-  <disable_collisions link1="panda_link3" link2="panda_rightfinger" reason="Never" />
+  <disable_collisions link1="panda_leftfinger" link2="panda_link8" reason="Never" />
   <disable_collisions link1="panda_link4" link2="panda_rightfinger" reason="Never" />
   <disable_collisions link1="panda_link6" link2="panda_rightfinger" reason="Never" />
   <disable_collisions link1="panda_link7" link2="panda_rightfinger" reason="Never" />
+  <disable_collisions link1="panda_link8" link2="panda_rightfinger" reason="Never" />
 </robot>


### PR DESCRIPTION
franka_description got updated with a more coarse collision model [1] matching the internal
self-collision detection, so the SRDF needs to be adapted.

Closes #18. Resolves ros-planning/moveit#1210, resolves frankaemika/franka_ros#39.

[1] https://github.com/frankaemika/franka_ros/commit/e52c03a23aa18c6532e40f9bf4927dedfc0c596a

---

The changes in franka_description were not released yet, but I wanted to open this PR already to get feedback. When this is merged, I guess we should coordinate to get both packages into the ROS repos at the same time (or maybe `panda_moveit_config` can already be released beforehand, not completely sure if this SRDF would cause problems with the old URDF).