### PR TITLE
Add fully extended pose: 'extended'

### DIFF
--- a/config/panda_arm_hand.srdf.xacro
+++ b/config/panda_arm_hand.srdf.xacro
@@ -27,7 +27,7 @@
     <joint name="panda_joint6" value="1.571" />
     <joint name="panda_joint7" value="0.785" />
   </group_state>
-  <group_state name="home" group="panda_arm_hand">
+  <group_state name="extended" group="panda_arm_hand">
     <joint name="panda_joint1" value="0" />
     <joint name="panda_joint2" value="0" />
     <joint name="panda_joint3" value="0" />

--- a/config/panda_arm_hand.srdf.xacro
+++ b/config/panda_arm_hand.srdf.xacro
@@ -27,6 +27,15 @@
     <joint name="panda_joint6" value="1.571" />
     <joint name="panda_joint7" value="0.785" />
   </group_state>
+  <group_state name="home" group="panda_arm_hand">
+    <joint name="panda_joint1" value="0" />
+    <joint name="panda_joint2" value="0" />
+    <joint name="panda_joint3" value="0" />
+    <joint name="panda_joint4" value="0" />
+    <joint name="panda_joint5" value="0" />
+    <joint name="panda_joint6" value="0" />
+    <joint name="panda_joint7" value="0.785" />
+  </group_state>
   <group_state name="open" group="hand">
     <joint name="panda_finger_joint1" value="0.035" />
     <joint name="panda_finger_joint2" value="0.035" />


### PR DESCRIPTION
![panda_home](https://user-images.githubusercontent.com/4572766/62712956-21e11c00-b9b9-11e9-8603-130f26015c0b.png)
This adds a simple named pose 'home' where the group `panda_arm_hand` is fully extended.