### PR TITLE
Change virtual joint type to fixed

### DIFF
--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -21,7 +21,7 @@
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="virtual_joint" type="floating" parent_frame="world" child_link="panda_link0" />
+    <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="panda_link0" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="panda_link0" link2="panda_link1" reason="Adjacent" />
     <disable_collisions link1="panda_link0" link2="panda_link2" reason="Never" />


### PR DESCRIPTION
Multiple issues opened after changing the virtual_joint type from fixed to floating, but after these PRs [PR#55](https://github.com/ros-planning/moveit_msgs/pull/55) and [PR#56](https://github.com/ros-planning/moveit_visual_tools/pull/56) there's no need for the type to be floating, changing the type to fixed solves these issues [panda_moveit_config: #33](https://github.com/ros-planning/panda_moveit_config/issues/33), [panda_moveit_config: #38](https://github.com/ros-planning/panda_moveit_config/issues/38), [moveit_tutorials: #312](https://github.com/ros-planning/moveit_tutorials/issues/312), [moveit: #1414](https://github.com/ros-planning/moveit/issues/1414), and [moveit: #1399](https://github.com/ros-planning/moveit/issues/1399)