### PR TITLE
added static transform publisher

### DIFF
--- a/launch/panda_control_moveit_rviz.launch
+++ b/launch/panda_control_moveit_rviz.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
 <launch>
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
+
   <arg name="robot_ip" />
   <arg name="load_gripper" default="true" />
   <arg name="launch_rviz" default="true" />


### PR DESCRIPTION
Adds a static publisher to the launch file to resolve a warning about missing joints and bring back the interactive markers in RVIZ.

resolves #49