### PR TITLE
Bug fixes: demo_chomp.launch does not display Interactive markers.

### DIFF
--- a/launch/demo_chomp.launch
+++ b/launch/demo_chomp.launch
@@ -25,7 +25,7 @@
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->
-  
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">


### PR DESCRIPTION
When executing `roslaunch panda_moveit_config demo_chomp.launch`, I added the `MotionPlanning` plugin and changed `Move Group` to `panda_arm`. However, Interactive markers is missing. The reason for this can be found in the warning msg: 

```
Loading 'move_group/MoveGroupExecuteTrajectoryAction'...                                                                                                                                                      
[ WARN] [1582773293.919377788]: Unable to update multi-DOF joint 'virtual_joint': Failure to lookup transform between 'world' and 'panda_link0' with TF exception: "world" passed to lookupTransform argument target_frame does not exist.                                                                                                                                                                                  
Loading 'move_group/MoveGroupGetPlanningSceneService'...                                                                                                                                                      
Loading 'move_group/MoveGroupKinematicsService'...
Loading 'move_group/MoveGroupMoveAction'...
``` 

The `world` is not added to the `tf tree`.