### PR TITLE
Bug fix: Lack of topp in stomp_planning_pipeline.launch

### DIFF
--- a/launch/stomp_planning_pipeline.launch.xml
+++ b/launch/stomp_planning_pipeline.launch.xml
@@ -4,11 +4,11 @@
   <arg name="planning_plugin" value="stomp_moveit/StompPlannerManager" />
 
   <!-- The request adapters (plugins) ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
-                                       default_planner_request_adapters/FixWorkspaceBounds
+  <arg name="planning_adapters" value="default_planner_request_adapters/FixWorkspaceBounds
                                        default_planner_request_adapters/FixStartStateBounds
                                        default_planner_request_adapters/FixStartStateCollision
-                                       default_planner_request_adapters/FixStartStatePathConstraints" />
+                                       default_planner_request_adapters/FixStartStatePathConstraints
+                                       default_planner_request_adapters/AddTimeParameterization" />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 

--- a/launch/stomp_planning_pipeline.launch.xml
+++ b/launch/stomp_planning_pipeline.launch.xml
@@ -4,7 +4,8 @@
   <arg name="planning_plugin" value="stomp_moveit/StompPlannerManager" />
 
   <!-- The request adapters (plugins) ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/FixWorkspaceBounds
+  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+                                       default_planner_request_adapters/FixWorkspaceBounds
                                        default_planner_request_adapters/FixStartStateBounds
                                        default_planner_request_adapters/FixStartStateCollision
                                        default_planner_request_adapters/FixStartStatePathConstraints" />


### PR DESCRIPTION
As it was described in [#58](https://github.com/ros-planning/panda_moveit_config/issues/58), the `planning_adapters` in `stomp_planning_pipeline.launch` should contain `default_planner_request_adapters/AddTimeParameterization`.