### PR TITLE
Disable collisions between link 7 and 8

### DIFF
--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -51,5 +51,6 @@
     <disable_collisions link1="panda_link4" link2="panda_link7" reason="Never" />
     <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent" />
     <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent" />
+    <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent" />
   </xacro:macro>
 </robot>


### PR DESCRIPTION
When planning a robot motion, we get the error message: _"Found a contact between 'panda_link7' (type 'Robot link') and 'panda_link8' (type 'Robot link'), which constitutes a collision. Contact information is not stored."_

I'm not sure if this is the best solution for this problem, but it avoids the collision check between the adjacent links and works for us.