### PR TITLE
Integrate with Gazebo

### DIFF
--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -1,64 +1,67 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
-  <xacro:macro name="panda_arm">
-    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
-    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
-    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
-    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
-    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
-    <group name="panda_arm">
-      <chain base_link="panda_link0" tip_link="panda_link8" />
-    </group>
-    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
-    <group_state name="ready" group="panda_arm">
-      <joint name="panda_joint1" value="0" />
-      <joint name="panda_joint2" value="-0.785" />
-      <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="-2.356" />
-      <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="1.571" />
-      <joint name="panda_joint7" value="0.785" />
-    </group_state>
-    <group_state name="extended" group="panda_arm">
-      <joint name="panda_joint1" value="0" />
-      <joint name="panda_joint2" value="0" />
-      <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="0" />
-      <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="0" />
-      <joint name="panda_joint7" value="0.785" />
-    </group_state>
-    <group_state name="transport" group="panda_arm">
-      <joint name="panda_joint1" value="0" />
-      <joint name="panda_joint2" value="-0.5599" />
-      <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="-2.97" />
-      <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="0" />
-      <joint name="panda_joint7" value="0.785" />
-    </group_state>
-    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
-    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="virtual_joint" type="floating" parent_frame="world" child_link="panda_link0" />
-    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
-    <disable_collisions link1="panda_link0" link2="panda_link1" reason="Adjacent" />
-    <disable_collisions link1="panda_link0" link2="panda_link2" reason="Never" />
-    <disable_collisions link1="panda_link0" link2="panda_link3" reason="Never" />
-    <disable_collisions link1="panda_link0" link2="panda_link4" reason="Never" />
-    <disable_collisions link1="panda_link1" link2="panda_link2" reason="Adjacent" />
-    <disable_collisions link1="panda_link1" link2="panda_link3" reason="Default" />
-    <disable_collisions link1="panda_link1" link2="panda_link4" reason="Never" />
-    <disable_collisions link1="panda_link2" link2="panda_link3" reason="Adjacent" />
-    <disable_collisions link1="panda_link2" link2="panda_link4" reason="Never" />
-    <disable_collisions link1="panda_link3" link2="panda_link4" reason="Adjacent" />
-    <disable_collisions link1="panda_link3" link2="panda_link6" reason="Never" />
-    <disable_collisions link1="panda_link4" link2="panda_link5" reason="Adjacent" />
-    <disable_collisions link1="panda_link4" link2="panda_link6" reason="Never" />
-    <disable_collisions link1="panda_link4" link2="panda_link7" reason="Never" />
-    <disable_collisions link1="panda_link4" link2="panda_link8" reason="Never" />
-    <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent" />
-    <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent" />
-    <disable_collisions link1="panda_link6" link2="panda_link8" reason="Default" />
-    <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent" />
-  </xacro:macro>
+    <xacro:macro name="panda_arm">
+        <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+        <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+        <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+        <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+        <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+        <group name="panda_arm">
+            <joint name="panda_joint1"/>
+            <joint name="panda_joint2"/>
+            <joint name="panda_joint3"/>
+            <joint name="panda_joint4"/>
+            <joint name="panda_joint5"/>
+            <joint name="panda_joint6"/>
+            <joint name="panda_joint7"/>
+            <joint name="panda_joint8"/>
+        </group>
+        <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+        <group_state name="ready" group="panda_arm">
+            <joint name="panda_joint1" value="0"/>
+            <joint name="panda_joint2" value="-0.785"/>
+            <joint name="panda_joint3" value="0"/>
+            <joint name="panda_joint4" value="-2.356"/>
+            <joint name="panda_joint5" value="0"/>
+            <joint name="panda_joint6" value="1.571"/>
+            <joint name="panda_joint7" value="-0.7855"/>
+        </group_state>
+        <group_state name="extended" group="panda_arm">
+            <joint name="panda_joint1" value="0"/>
+            <joint name="panda_joint2" value="-0.3927"/>
+            <joint name="panda_joint3" value="0"/>
+            <joint name="panda_joint4" value="-0.7855"/>
+            <joint name="panda_joint5" value="0"/>
+            <joint name="panda_joint6" value="3.142"/>
+            <joint name="panda_joint7" value="-0.785"/>
+        </group_state>
+        <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+        <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="panda_link0"/>
+        <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+        <disable_collisions link1="panda_link0" link2="panda_link1" reason="Adjacent"/>
+        <disable_collisions link1="panda_link0" link2="panda_link2" reason="Never"/>
+        <disable_collisions link1="panda_link0" link2="panda_link3" reason="Never"/>
+        <disable_collisions link1="panda_link0" link2="panda_link4" reason="Never"/>
+        <disable_collisions link1="panda_link1" link2="panda_link2" reason="Adjacent"/>
+        <disable_collisions link1="panda_link1" link2="panda_link3" reason="Default"/>
+        <disable_collisions link1="panda_link1" link2="panda_link4" reason="Never"/>
+        <disable_collisions link1="panda_link2" link2="panda_link3" reason="Adjacent"/>
+        <disable_collisions link1="panda_link2" link2="panda_link4" reason="Never"/>
+        <disable_collisions link1="panda_link3" link2="panda_link4" reason="Adjacent"/>
+        <disable_collisions link1="panda_link3" link2="panda_link6" reason="Never"/>
+        <disable_collisions link1="panda_link4" link2="panda_link5" reason="Adjacent"/>
+        <disable_collisions link1="panda_link4" link2="panda_link6" reason="Never"/>
+        <disable_collisions link1="panda_link4" link2="panda_link7" reason="Never"/>
+        <disable_collisions link1="panda_link4" link2="panda_link8" reason="Never"/>
+        <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent"/>
+        <disable_collisions link1="panda_link5" link2="panda_link7" reason="Default"/>
+        <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent"/>
+        <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent"/>
+        <!-- Fix self-collisions between too coarse collision geometries provided by franka_description
+             See https://github.com/ros-planning/panda_moveit_config/issues/72#issuecomment-768472329
+                 https://github.com/ros-planning/panda_moveit_config/pull/35#pullrequestreview-390715967
+        -->
+        <disable_collisions link1="panda_link5" link2="panda_link8" reason="Default" />
+        <disable_collisions link1="panda_link6" link2="panda_link8" reason="Default"/>
+    </xacro:macro>
 </robot>

--- a/config/ros_controllers.yaml
+++ b/config/ros_controllers.yaml
@@ -1,0 +1,20 @@
+# Simulation settings for using moveit_sim_controllers
+moveit_sim_hw_interface:
+  joint_model_group: panda_arm
+  joint_model_group_pose: ready
+# Settings for ros_control_boilerplate control loop
+generic_hw_control_loop:
+  loop_hz: 300
+  cycle_time_error_threshold: 0.01
+# Settings for ros_control hardware interface
+hardware_interface:
+  joints:
+    - panda_joint1
+    - panda_joint2
+    - panda_joint3
+    - panda_joint4
+    - panda_joint5
+    - panda_joint6
+    - panda_joint7
+    - panda_finger_joint1
+  sim_control_mode: 1  # 0: position, 1: velocity

--- a/launch/demo_gazebo.launch
+++ b/launch/demo_gazebo.launch
@@ -23,10 +23,11 @@
     <arg name="paused" value="$(arg paused)"/>
     <arg name="use_gripper" default="$(arg load_gripper)"/>
     <arg name="transmission" value="hardware_interface/PositionJointInterface"/>
+    <arg name="controller" value="position_joint_trajectory_controller"/>
   </include>
 
   <!-- Load position_joint_trajectory_controller -->
-  <include ns="panda" file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
+  <include file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
   <include ns="panda" file="$(find panda_moveit_config)/launch/move_group.launch">
@@ -35,12 +36,10 @@
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="false"/>
     <arg name="load_gripper" value="$(arg load_gripper)"/>
-    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
   <include ns="panda" file="$(dirname)/moveit_rviz.launch">
-    <arg name="rviz_config" value="$(find panda_moveit_config)/launch/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 

--- a/launch/demo_gazebo.launch
+++ b/launch/demo_gazebo.launch
@@ -1,0 +1,52 @@
+<launch>
+
+  <!-- By default, we do not start a database (it can be large) -->
+  <arg name="db" default="false" />
+  <!-- Allow user to specify database location -->
+  <arg name="db_path" default="$(find panda_moveit_config)/default_warehouse_mongo_db" />
+
+  <!-- By default, we are not in debug mode -->
+  <arg name="debug" default="false" />
+
+  <!-- By default, we won't load or override the robot_description -->
+  <arg name="load_robot_description" default="false"/>
+  <arg name="load_gripper" default="true" />
+
+  <!-- Gazebo specific options -->
+  <arg name="gazebo_gui" default="true"/>
+  <arg name="paused" default="false"/>
+
+  <!-- launch the gazebo simulator and spawn the robot -->
+  <include file="$(find franka_gazebo)/launch/panda.launch">
+    <arg unless="$(arg gazebo_gui)" name="headless" value="true"/>
+    <arg     if="$(arg gazebo_gui)" name="headless" value="false"/>
+    <arg name="paused" value="$(arg paused)"/>
+    <arg name="use_gripper" default="$(arg load_gripper)"/>
+    <arg name="transmission" value="hardware_interface/PositionJointInterface"/>
+  </include>
+
+  <!-- Load position_joint_trajectory_controller -->
+  <include ns="panda" file="$(find panda_moveit_config)/launch/ros_controllers.launch"/>
+
+  <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
+  <include ns="panda" file="$(find panda_moveit_config)/launch/move_group.launch">
+    <arg name="info" value="true"/>
+    <arg name="debug" value="$(arg debug)"/>
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="false"/>
+    <arg name="load_gripper" value="$(arg load_gripper)"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
+  </include>
+
+  <!-- Run Rviz and load the default config to see the state of the move_group node -->
+  <include ns="panda" file="$(dirname)/moveit_rviz.launch">
+    <arg name="rviz_config" value="$(find panda_moveit_config)/launch/moveit.rviz"/>
+    <arg name="debug" value="$(arg debug)"/>
+  </include>
+
+  <!-- If database loading was enabled, start mongodb as well -->
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
+    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
+  </include>
+
+</launch>

--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -8,7 +8,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param name="$(arg robot_description)" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
+  <param name="$(arg robot_description)" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" if="$(arg load_robot_description)"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" if="$(arg load_gripper)" />

--- a/launch/ros_controllers.launch
+++ b/launch/ros_controllers.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- Load joint controller configurations from YAML file to parameter server -->
+  <rosparam file="$(find panda_moveit_config)/config/ros_controllers.yaml" command="load"/>
+
+  <!-- Load the controllers -->
+  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="position_joint_trajectory_controller"/>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -25,8 +25,12 @@
   <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
-  <run_depend>topic_tools</run_depend>
-  <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment.
-       Commented the dependency until this works. -->
+  <run_depend>moveit_visual_tools</run_depend>
+  <!-- The next 2 packages are required for the gazebo simulation.
+      We don't include them by default to prevent installing gazebo and all its dependencies. -->
+  <!-- <run_depend>joint_trajectory_controller</run_depend> -->
+  <!-- <run_depend>gazebo_ros_control</run_depend> -->
+  <!-- <run_depend>franka_gazebo</run_depend> -->
+  <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
 </package>


### PR DESCRIPTION
~Needs a bit more work to have the minimal intrusion.~

Now it should be ready. The bulk of the change is due to now filled `moveit.rviz`. The version in the base repo is an almost empty -- default Rviz config file, whereas now all the juicy MoveIt stuff is loaded within.