### PR TITLE
Fix ordering of planning adapters

### DIFF
--- a/launch/chomp_planning_pipeline.launch.xml
+++ b/launch/chomp_planning_pipeline.launch.xml
@@ -5,12 +5,12 @@
 
    <param name="planning_plugin" value="$(arg planning_plugin)" />
    <param name="request_adapters" value="
+       default_planner_request_adapters/AddTimeParameterization
        default_planner_request_adapters/FixWorkspaceBounds
        default_planner_request_adapters/FixStartStateBounds
        default_planner_request_adapters/FixStartStateCollision
        default_planner_request_adapters/FixStartStatePathConstraints
-       default_planner_request_adapters/ResolveConstraintFrames
-       default_planner_request_adapters/AddTimeParameterization"
+       default_planner_request_adapters/ResolveConstraintFrames"
        />
    <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 

--- a/launch/ompl-chomp_planning_pipeline.launch.xml
+++ b/launch/ompl-chomp_planning_pipeline.launch.xml
@@ -2,12 +2,12 @@
   <!-- load OMPL planning pipeline, but add the CHOMP planning adapter. -->
   <include file="$(find panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml">
     <arg name="planning_adapters" value="
+       default_planner_request_adapters/AddTimeParameterization
        default_planner_request_adapters/FixWorkspaceBounds
        default_planner_request_adapters/FixStartStateBounds
        default_planner_request_adapters/FixStartStateCollision
        default_planner_request_adapters/FixStartStatePathConstraints
-       chomp/OptimizerAdapter
-       default_planner_request_adapters/AddTimeParameterization"
+       chomp/OptimizerAdapter"
        />
   </include>
   <!-- load chomp config -->

--- a/launch/ompl_planning_pipeline.launch.xml
+++ b/launch/ompl_planning_pipeline.launch.xml
@@ -6,12 +6,12 @@
   <!-- The request adapters (plugins) used when planning with OMPL. 
        ORDER MATTERS -->
   <arg name="planning_adapters" default="
+       default_planner_request_adapters/AddTimeParameterization
+       default_planner_request_adapters/ResolveConstraintFrames
        default_planner_request_adapters/FixWorkspaceBounds
        default_planner_request_adapters/FixStartStateBounds
        default_planner_request_adapters/FixStartStateCollision
-       default_planner_request_adapters/FixStartStatePathConstraints
-       default_planner_request_adapters/ResolveConstraintFrames
-       default_planner_request_adapters/AddTimeParameterization"
+       default_planner_request_adapters/FixStartStatePathConstraints"
        />
   <arg name="start_state_max_bounds_error" value="0.1" />
 

--- a/launch/stomp_planning_pipeline.launch.xml
+++ b/launch/stomp_planning_pipeline.launch.xml
@@ -4,11 +4,11 @@
   <arg name="planning_plugin" value="stomp_moveit/StompPlannerManager" />
 
   <!-- The request adapters (plugins) ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/FixWorkspaceBounds
+  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+                                       default_planner_request_adapters/FixWorkspaceBounds
                                        default_planner_request_adapters/FixStartStateBounds
                                        default_planner_request_adapters/FixStartStateCollision
-                                       default_planner_request_adapters/FixStartStatePathConstraints
-                                       default_planner_request_adapters/AddTimeParameterization" />
+                                       default_planner_request_adapters/FixStartStatePathConstraints" />
 
   <arg name="start_state_max_bounds_error" value="0.1" />
 


### PR DESCRIPTION
As explained in https://github.com/ros-planning/moveit/pull/2053, AddTimeParameterization should be at the begining of the list.

I tried trajectry execution with `pipeline:=ompl-chomp` on [gazebo simulation](https://github.com/tnaka/panda_simulation), and got this error.
```
[ERROR] [1596992896.473259092, 34.748000000]: Trajectory message contains waypoints that are not strictly increasing in time.
```
This PR resolves the problem.