### PR TITLE
Adds the ability to specify the rviz file

### DIFF
--- a/launch/moveit_rviz.launch
+++ b/launch/moveit_rviz.launch
@@ -5,7 +5,8 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="rviz_tutorial" default="false" />
-  <arg unless="$(arg rviz_tutorial)" name="command_args" value="-d $(find panda_moveit_config)/launch/moveit.rviz" />
+  <arg name="rviz_file" default="$(find panda_moveit_config)/launch/moveit.rviz" />
+  <arg unless="$(arg rviz_tutorial)" name="command_args" value="-d $(arg rviz_file)" />
   <arg     if="$(arg rviz_tutorial)" name="command_args" value="-d $(find panda_moveit_config)/launch/moveit_empty.rviz" />
 
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"


### PR DESCRIPTION
This commit gives users the ability to specify the RVIZ configuration file that is used. This is useful for loading custom RVIZ configuration files.