### PR TITLE
Fixes CMP0048 CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.4)
 project(panda_moveit_config)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Removes the CMP0048 CMake warning that is thrown when the CMAKE version is too low.