### PR TITLE
Adds 'demo_stomp' launch file #44

### DIFF
--- a/launch/demo_stomp.launch
+++ b/launch/demo_stomp.launch
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(dirname)/demo.launch">
+    <arg name="pipeline" value="stomp"/>
+  </include>
+</launch>


### PR DESCRIPTION
This commit adds the 'demo_stomp.launch' file that is referenced in https://ros-planning.github.io/moveit_tutorials/doc/stomp_planner/stomp_planner_tutorial.html.