### PR TITLE
use panda_arm description with hand arg

### DIFF
--- a/.setup_assistant
+++ b/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: franka_description
-    relative_path: robots/panda_arm_hand.urdf.xacro
+    relative_path: robots/panda_arm.urdf.xacro
   SRDF:
     relative_path: config/panda_arm.srdf.xacro
   CONFIG:

--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -8,7 +8,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param name="$(arg robot_description)" command="$(find xacro)/xacro --inorder $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
+  <param name="$(arg robot_description)" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" if="$(arg load_gripper)" />

--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -8,8 +8,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(eval arg('load_robot_description') and arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
-  <param if="$(eval arg('load_robot_description') and not arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'"/>
+  <param name="$(arg robot_description)" command="$(find xacro)/xacro --inorder $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" if="$(arg load_gripper)" />


### PR DESCRIPTION
Problem:
`` roslaunch panda_moveit_config demo.launch``
raises:
```
No such file or directory: /opt/ros/noetic/share/franka_description/robots/panda_arm_hand.urdf.xacro [Errno 2] No such file or directory: '/opt/ros/noetic/share/franka_description/robots/panda_arm_hand.urdf.xacro'
RLException: while processing /home/gah/tasks_ws/src/panda_moveit_config/launch/planning_context.launch:
Invalid <param> tag: Cannot load command parameter [robot_description]: command [['/opt/ros/noetic/lib/xacro/xacro', '/opt/ros/noetic/share/franka_description/robots/panda_arm_hand.urdf.xacro']] returned with code [2]. 

Param xml is <param if="$(eval arg('load_robot_description') and arg('load_gripper'))" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
The traceback for the exception was written to the log file
```

Solution:
``panda_arm_hand.urdf.xacro`` has been replaced by ``panda_arm.urdf.xacro hand:=$(arg load_gripper)``
see: https://github.com/frankaemika/franka_ros/commit/2dc885213c6a658a274146a1139ca1c4bfc93017