### PR TITLE
Fix poses and update disabled collisons

### DIFF
--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
   <xacro:macro name="panda_arm">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
@@ -12,34 +12,25 @@
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="ready" group="panda_arm">
       <joint name="panda_joint1" value="0" />
-      <joint name="panda_joint2" value="-0.785" />
+      <joint name="panda_joint2" value="${-pi/4}" />
       <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="-2.356" />
+      <joint name="panda_joint4" value="${-3*pi/4}" />
       <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="1.571" />
-      <joint name="panda_joint7" value="0.785" />
+      <joint name="panda_joint6" value="${pi/2}" />
+      <joint name="panda_joint7" value="${pi/4}" />
     </group_state>
     <group_state name="extended" group="panda_arm">
       <joint name="panda_joint1" value="0" />
       <joint name="panda_joint2" value="0" />
       <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="0" />
+      <joint name="panda_joint4" value="-0.1" />
       <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="0" />
-      <joint name="panda_joint7" value="0.785" />
-    </group_state>
-    <group_state name="transport" group="panda_arm">
-      <joint name="panda_joint1" value="0" />
-      <joint name="panda_joint2" value="-0.5599" />
-      <joint name="panda_joint3" value="0" />
-      <joint name="panda_joint4" value="-2.97" />
-      <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="0" />
-      <joint name="panda_joint7" value="0.785" />
+      <joint name="panda_joint6" value="${pi/2}" />
+      <joint name="panda_joint7" value="${pi/4}" />
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="virtual_joint" type="floating" parent_frame="world" child_link="panda_link0" />
+    <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="panda_link0" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="panda_link0" link2="panda_link1" reason="Adjacent" />
     <disable_collisions link1="panda_link0" link2="panda_link2" reason="Never" />
@@ -51,14 +42,21 @@
     <disable_collisions link1="panda_link2" link2="panda_link3" reason="Adjacent" />
     <disable_collisions link1="panda_link2" link2="panda_link4" reason="Never" />
     <disable_collisions link1="panda_link3" link2="panda_link4" reason="Adjacent" />
+    <disable_collisions link1="panda_link3" link2="panda_link5" reason="Default" />
     <disable_collisions link1="panda_link3" link2="panda_link6" reason="Never" />
     <disable_collisions link1="panda_link4" link2="panda_link5" reason="Adjacent" />
     <disable_collisions link1="panda_link4" link2="panda_link6" reason="Never" />
     <disable_collisions link1="panda_link4" link2="panda_link7" reason="Never" />
     <disable_collisions link1="panda_link4" link2="panda_link8" reason="Never" />
     <disable_collisions link1="panda_link5" link2="panda_link6" reason="Adjacent" />
+    <disable_collisions link1="panda_link5" link2="panda_link7" reason="Default" />
     <disable_collisions link1="panda_link6" link2="panda_link7" reason="Adjacent" />
-    <disable_collisions link1="panda_link6" link2="panda_link8" reason="Default" />
     <disable_collisions link1="panda_link7" link2="panda_link8" reason="Adjacent" />
+    <!-- Fix self-collisions between too coarse collision geometries provided by franka_description
+             See https://github.com/ros-planning/panda_moveit_config/issues/72#issuecomment-768472329
+                 https://github.com/ros-planning/panda_moveit_config/pull/35#pullrequestreview-390715967
+        -->
+    <disable_collisions link1="panda_link5" link2="panda_link8" reason="Default" />
+    <disable_collisions link1="panda_link6" link2="panda_link8" reason="Default" />
   </xacro:macro>
 </robot>

--- a/config/panda_arm.xacro
+++ b/config/panda_arm.xacro
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
   <xacro:macro name="panda_arm">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->


### PR DESCRIPTION
Currently, the interactive markers in Rviz are not visible when using moveit. To bring it back I disabled a few collisions (similar to what @rickstaa did in the noetic-branch), removed the "transport" pose, as this one is not reachable with the collision volumes. Also I changed the "extended" pose so that it does not violate the joint limits anymore.

As a result the interactive markers are now back.