### PR TITLE
FIX: Don't try to start `franka_gripper` controller

### DIFF
--- a/launch/ros_controllers.launch
+++ b/launch/ros_controllers.launch
@@ -6,5 +6,5 @@
 
   <!-- Load and start the controllers -->
   <node ns="/" name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-        args="$(arg transmission)_joint_trajectory_controller franka_gripper" />
+        args="$(arg transmission)_joint_trajectory_controller" />
 </launch>


### PR DESCRIPTION
## Steps to reproduce 

```console
$ cd panda_moveit_config
$ git checkout noetic-devel
$ catkin build

$ roslaunch panda_moveit_config franka_control.launch robot_ip:=<MY-ROBOT>
...
[ERROR] Could not load controller 'franka_gripper' because controller type 'GripperCommand' does not exist.
...
```

## Fix

The gripper controller is automatically started in [franka_control](https://github.com/ros-planning/panda_moveit_config/blob/noetic-devel/launch/franka_control.launch#L4) (whenever `use_gripper:=true`), simply don't try to start it =)