### PR TITLE
Fix/manipulator move group

### DIFF
--- a/config/kinematics.yaml
+++ b/config/kinematics.yaml
@@ -1,4 +1,3 @@
-panda_arm:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.05
+kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+kinematics_solver_search_resolution: 0.005
+kinematics_solver_timeout: 0.05

--- a/config/ompl_planning.yaml
+++ b/config/ompl_planning.yaml
@@ -127,7 +127,7 @@ planner_configs:
     sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
-panda_arm:
+panda_arm: &group_config
   planner_configs:
     - AnytimePathShortening
     - SBL
@@ -181,31 +181,4 @@ hand:
     - LazyPRMstar
     - SPARS
     - SPARStwo
-panda_arm_hand:
-  planner_configs:
-    - AnytimePathShortening
-    - SBL
-    - EST
-    - LBKPIECE
-    - BKPIECE
-    - KPIECE
-    - RRT
-    - RRTConnect
-    - RRTstar
-    - TRRT
-    - PRM
-    - PRMstar
-    - FMT
-    - BFMT
-    - PDST
-    - STRIDE
-    - BiTRRT
-    - LBTRRT
-    - BiEST
-    - ProjEST
-    - LazyPRM
-    - LazyPRMstar
-    - SPARS
-    - SPARStwo
-  projection_evaluator: joints(panda_joint1,panda_joint2)
-  longest_valid_segment_fraction: 0.005
+manipulator: *group_config

--- a/config/stomp_planning.yaml
+++ b/config/stomp_planning.yaml
@@ -1,40 +1,37 @@
-
-stomp/panda_arm:
-  group_name: panda_arm
-  optimization:
-    num_timesteps: 60
-    num_iterations: 40
-    num_iterations_after_valid: 0
-    num_rollouts: 30
-    max_rollouts: 30
-    initialization_method: 1 #[1 : LINEAR_INTERPOLATION, 2 : CUBIC_POLYNOMIAL, 3 : MININUM_CONTROL_COST]
-    control_cost_weight: 0.0
-  task:
-    noise_generator:
-      - class: stomp_moveit/NormalDistributionSampling
-        stddev: [0.05, 0.8, 1.0, 0.8, 0.4, 0.4, 0.4]
-    cost_functions:
-      - class: stomp_moveit/CollisionCheck
-        collision_penalty: 1.0
-        cost_weight: 1.0
-        kernel_window_percentage: 0.2
-        longest_valid_joint_move: 0.05
-    noisy_filters:
-      - class: stomp_moveit/JointLimits
-        lock_start: True
-        lock_goal: True
-      - class: stomp_moveit/MultiTrajectoryVisualization
-        line_width: 0.02
-        rgb: [255, 255, 0]
-        marker_array_topic: stomp_trajectories
-        marker_namespace: noisy
-    update_filters:
-      - class: stomp_moveit/PolynomialSmoother
-        poly_order: 6
-      - class: stomp_moveit/TrajectoryVisualization
-        line_width: 0.05
-        rgb: [0, 191, 255]
-        error_rgb: [255, 0, 0]
-        publish_intermediate: True
-        marker_topic: stomp_trajectory
-        marker_namespace: optimized
+optimization:
+  num_timesteps: 60
+  num_iterations: 40
+  num_iterations_after_valid: 0
+  num_rollouts: 30
+  max_rollouts: 30
+  initialization_method: 1 #[1 : LINEAR_INTERPOLATION, 2 : CUBIC_POLYNOMIAL, 3 : MININUM_CONTROL_COST]
+  control_cost_weight: 0.0
+task:
+  noise_generator:
+    - class: stomp_moveit/NormalDistributionSampling
+      stddev: [0.05, 0.8, 1.0, 0.8, 0.4, 0.4, 0.4]
+  cost_functions:
+    - class: stomp_moveit/CollisionCheck
+      collision_penalty: 1.0
+      cost_weight: 1.0
+      kernel_window_percentage: 0.2
+      longest_valid_joint_move: 0.05
+  noisy_filters:
+    - class: stomp_moveit/JointLimits
+      lock_start: True
+      lock_goal: True
+    - class: stomp_moveit/MultiTrajectoryVisualization
+      line_width: 0.02
+      rgb: [255, 255, 0]
+      marker_array_topic: stomp_trajectories
+      marker_namespace: noisy
+  update_filters:
+    - class: stomp_moveit/PolynomialSmoother
+      poly_order: 6
+    - class: stomp_moveit/TrajectoryVisualization
+      line_width: 0.05
+      rgb: [0, 191, 255]
+      error_rgb: [255, 0, 0]
+      publish_intermediate: True
+      marker_topic: stomp_trajectory
+      marker_namespace: optimized

--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -20,8 +20,8 @@
 
   <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
   <group ns="$(arg robot_description)_kinematics">
-    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
-
+    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml" ns="panda_arm"/>
+    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml" ns="manipulator"/>
   </group>
 
 </launch>

--- a/launch/stomp_planning_pipeline.launch.xml
+++ b/launch/stomp_planning_pipeline.launch.xml
@@ -21,5 +21,10 @@
   <!-- Add MoveGroup capabilities specific to this pipeline -->
   <!-- <param name="capabilities" value="" /> -->
 
-  <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml"/>
+  <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml" ns="stomp/panda_arm"/>
+  <param name="stomp/panda_arm" value="panda_arm" />
+
+  <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml" ns="stomp/manipulator"/>
+  <param name="stomp/manipulator" value="manipulator" />
+
 </launch>


### PR DESCRIPTION
One potential fix to https://github.com/ros-planning/panda_moveit_config/issues/101. I think the main problem is that many configs were missing for the move group `manipulator`. Note, though, that with these fixes actually _two_ gizmos will be shown in RVIZ Motion planning when the `manipulator` is selected. Probably a bug in the Visualization
![Screenshot from 2022-02-09 10-04-51](https://user-images.githubusercontent.com/31999281/153161776-089826d2-592b-4668-99d5-016c0391d411.png)
