### PR TITLE
franka_control.launch: Start ROS controllers in correct namespace

### DIFF
--- a/config/arm.xacro
+++ b/config/arm.xacro
@@ -51,20 +51,16 @@
     <enable_collisions link1="$(arg arm_id)_link0_sc" link2="$(arg arm_id)_link5_sc" />
     <enable_collisions link1="$(arg arm_id)_link0_sc" link2="$(arg arm_id)_link6_sc" />
     <enable_collisions link1="$(arg arm_id)_link0_sc" link2="$(arg arm_id)_link7_sc" />
-    <enable_collisions link1="$(arg arm_id)_link0_sc" link2="$(arg arm_id)_link8_sc" />
     <xacro:collision link="$(arg arm_id)_link1" />
     <enable_collisions link1="$(arg arm_id)_link1_sc" link2="$(arg arm_id)_link5_sc" />
     <enable_collisions link1="$(arg arm_id)_link1_sc" link2="$(arg arm_id)_link6_sc" />
     <enable_collisions link1="$(arg arm_id)_link1_sc" link2="$(arg arm_id)_link7_sc" />
-    <enable_collisions link1="$(arg arm_id)_link1_sc" link2="$(arg arm_id)_link8_sc" />
     <xacro:collision link="$(arg arm_id)_link2" />
     <enable_collisions link1="$(arg arm_id)_link2_sc" link2="$(arg arm_id)_link5_sc" />
     <enable_collisions link1="$(arg arm_id)_link2_sc" link2="$(arg arm_id)_link6_sc" />
     <enable_collisions link1="$(arg arm_id)_link2_sc" link2="$(arg arm_id)_link7_sc" />
-    <enable_collisions link1="$(arg arm_id)_link2_sc" link2="$(arg arm_id)_link8_sc" />
     <xacro:collision link="$(arg arm_id)_link3" />
     <enable_collisions link1="$(arg arm_id)_link3_sc" link2="$(arg arm_id)_link7_sc" />
-    <enable_collisions link1="$(arg arm_id)_link3_sc" link2="$(arg arm_id)_link8_sc" />
     <xacro:collision link="$(arg arm_id)_link4" />
     <xacro:collision link="$(arg arm_id)_link5" />
     <xacro:collision link="$(arg arm_id)_link6" />

--- a/config/kinematics.yaml
+++ b/config/kinematics.yaml
@@ -3,4 +3,4 @@ $(arg arm_id)_arm: &arm_config
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.05
 
-manipulator: *arm_config
+$(arg arm_id)_manipulator: *arm_config

--- a/launch/franka_control.launch
+++ b/launch/franka_control.launch
@@ -2,8 +2,11 @@
 <launch>
   <!-- Launch real-robot control -->
   <include file="$(find franka_control)/launch/franka_control.launch" pass_all_args="true" />
+
   <!-- By default use joint position controllers -->
   <arg name="transmission" default="position" />
+  <!-- Start ROS controllers -->
+  <include file="$(dirname)/ros_controllers.launch" pass_all_args="true" />
 
   <!-- as well as MoveIt demo -->
   <include file="$(dirname)/demo.launch" pass_all_args="true">

--- a/launch/ros_controllers.launch
+++ b/launch/ros_controllers.launch
@@ -5,6 +5,6 @@
   <rosparam file="$(find panda_moveit_config)/config/ros_controllers.yaml" command="load"  subst_value="true"/>
 
   <!-- Load and start the controllers -->
-  <node ns="/$(arg arm_id)" name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
         args="$(arg transmission)_joint_trajectory_controller" />
 </launch>

--- a/launch/simple_moveit_controller_manager.launch.xml
+++ b/launch/simple_moveit_controller_manager.launch.xml
@@ -4,6 +4,4 @@
 
   <!-- Load controller list to the parameter server -->
   <rosparam subst_value="true" file="$(find panda_moveit_config)/config/simple_moveit_controllers.yaml" />
-  <!-- Start ROS controllers -->
-  <include file="$(dirname)/ros_controllers.launch" pass_all_args="true" />
 </launch>


### PR DESCRIPTION
#106 introduced a new bug, starting the controller_spawner in the wrong namespace.