### PR TITLE
FIX: Use `arm_id` arg also for `panda_manipulator` move group

### DIFF
--- a/config/kinematics.yaml
+++ b/config/kinematics.yaml
@@ -3,4 +3,4 @@ $(arg arm_id)_arm: &arm_config
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.05
 
-manipulator: *arm_config
+$(arg arm_id)_manipulator: *arm_config


### PR DESCRIPTION
... to be consistent with `panda_arm` move group