### PR TITLE
workaround for demo_stomp.launch

### DIFF
--- a/config/stomp_planning.yaml
+++ b/config/stomp_planning.yaml
@@ -1,37 +1,39 @@
-optimization:
-  num_timesteps: 60
-  num_iterations: 40
-  num_iterations_after_valid: 0
-  num_rollouts: 30
-  max_rollouts: 30
-  initialization_method: 1 #[1 : LINEAR_INTERPOLATION, 2 : CUBIC_POLYNOMIAL, 3 : MININUM_CONTROL_COST]
-  control_cost_weight: 0.0
-task:
-  noise_generator:
-    - class: stomp_moveit/NormalDistributionSampling
-      stddev: [0.05, 0.8, 1.0, 0.8, 0.4, 0.4, 0.4]
-  cost_functions:
-    - class: stomp_moveit/CollisionCheck
-      collision_penalty: 1.0
-      cost_weight: 1.0
-      kernel_window_percentage: 0.2
-      longest_valid_joint_move: 0.05
-  noisy_filters:
-    - class: stomp_moveit/JointLimits
-      lock_start: True
-      lock_goal: True
-    - class: stomp_moveit/MultiTrajectoryVisualization
-      line_width: 0.02
-      rgb: [255, 255, 0]
-      marker_array_topic: stomp_trajectories
-      marker_namespace: noisy
-  update_filters:
-    - class: stomp_moveit/PolynomialSmoother
-      poly_order: 6
-    - class: stomp_moveit/TrajectoryVisualization
-      line_width: 0.05
-      rgb: [0, 191, 255]
-      error_rgb: [255, 0, 0]
-      publish_intermediate: True
-      marker_topic: stomp_trajectory
-      marker_namespace: optimized
+stomp/panda_arm:
+  group_name: panda_arm
+  optimization:
+    num_timesteps: 60
+    num_iterations: 40
+    num_iterations_after_valid: 0
+    num_rollouts: 30
+    max_rollouts: 30
+    initialization_method: 1 #[1 : LINEAR_INTERPOLATION, 2 : CUBIC_POLYNOMIAL, 3 : MININUM_CONTROL_COST]
+    control_cost_weight: 0.0
+  task:
+    noise_generator:
+      - class: stomp_moveit/NormalDistributionSampling
+        stddev: [0.05, 0.8, 1.0, 0.8, 0.4, 0.4, 0.4]
+    cost_functions:
+      - class: stomp_moveit/CollisionCheck
+        collision_penalty: 1.0
+        cost_weight: 1.0
+        kernel_window_percentage: 0.2
+        longest_valid_joint_move: 0.05
+    noisy_filters:
+      - class: stomp_moveit/JointLimits
+        lock_start: True
+        lock_goal: True
+      - class: stomp_moveit/MultiTrajectoryVisualization
+        line_width: 0.02
+        rgb: [255, 255, 0]
+        marker_array_topic: stomp_trajectories
+        marker_namespace: noisy
+    update_filters:
+      - class: stomp_moveit/PolynomialSmoother
+        poly_order: 6
+      - class: stomp_moveit/TrajectoryVisualization
+        line_width: 0.05
+        rgb: [0, 191, 255]
+        error_rgb: [255, 0, 0]
+        publish_intermediate: True
+        marker_topic: stomp_trajectory
+        marker_namespace: optimized

--- a/launch/stomp_planning_pipeline.launch.xml
+++ b/launch/stomp_planning_pipeline.launch.xml
@@ -20,15 +20,16 @@
 
   <!-- Add MoveGroup capabilities specific to this pipeline -->
   <!-- <param name="capabilities" value="" /> -->
+  <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml" />
 
   <!-- Load parameters for both groups, panda_arm and manipulator -->
-  <group ns="$(arg arm_id)_arm">
+  <!-- <group ns="$(arg arm_id)_arm">
     <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml" />
     <param name="group_name" value="$(arg arm_id)_arm" />
   </group>
   <group ns="manipulator">
     <rosparam command="load" file="$(find panda_moveit_config)/config/stomp_planning.yaml" />
     <param name="group_name" value="manipulator" />
-  </group>
+  </group> -->
 
 </launch>


### PR DESCRIPTION
The [demo_stomp.launch](https://github.com/ros-planning/panda_moveit_config/blob/b5ce35571832b4165f67f5db51c69581354d2cee/launch/demo_stomp.launch) at the latest commit, i.e. https://github.com/ros-planning/panda_moveit_config/commit/b5ce35571832b4165f67f5db51c69581354d2cee shows following error:

```
[ERROR] [1690719183.898887624]: The 'stomp' configuration parameter was not found
```

Below is the complete log:
```
$ roslaunch panda_moveit_config demo_stomp.launch 
... logging to /home/test/.ros/log/6ebbbbb0-2ed2-11ee-8754-c783d253aba5/roslaunch-vm20test-198817.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://vm20test:38655/

SUMMARY
========

PARAMETERS
 * /joint_state_publisher/source_list: ['move_group/fake...
 * /move_group/allow_trajectory_execution: True
 * /move_group/capabilities: 
 * /move_group/controller_list: [{'name': 'fake_p...
 * /move_group/default_planning_pipeline: stomp
 * /move_group/disable_capabilities: 
 * /move_group/initial: [{'group': 'panda...
 * /move_group/max_range: 5.0
 * /move_group/moveit_controller_manager: moveit_fake_contr...
 * /move_group/moveit_manage_controllers: True
 * /move_group/octomap_frame: camera_rgb_optica...
 * /move_group/octomap_resolution: 0.025
 * /move_group/planning_pipelines/chomp/collision_clearance: 0.2
 * /move_group/planning_pipelines/chomp/collision_threshold: 0.07
 * /move_group/planning_pipelines/chomp/enable_failure_recovery: False
 * /move_group/planning_pipelines/chomp/jiggle_fraction: 0.05
 * /move_group/planning_pipelines/chomp/joint_update_limit: 0.1
 * /move_group/planning_pipelines/chomp/learning_rate: 0.01
 * /move_group/planning_pipelines/chomp/max_iterations: 200
 * /move_group/planning_pipelines/chomp/max_iterations_after_collision_free: 5
 * /move_group/planning_pipelines/chomp/max_recovery_attempts: 5
 * /move_group/planning_pipelines/chomp/obstacle_cost_weight: 1.0
 * /move_group/planning_pipelines/chomp/planning_plugin: chomp_interface/C...
 * /move_group/planning_pipelines/chomp/planning_time_limit: 10.0
 * /move_group/planning_pipelines/chomp/pseudo_inverse_ridge_factor: 1e-4
 * /move_group/planning_pipelines/chomp/request_adapters: default_planner_r...
 * /move_group/planning_pipelines/chomp/ridge_factor: 0.0
 * /move_group/planning_pipelines/chomp/smoothness_cost_acceleration: 1.0
 * /move_group/planning_pipelines/chomp/smoothness_cost_jerk: 0.0
 * /move_group/planning_pipelines/chomp/smoothness_cost_velocity: 0.0
 * /move_group/planning_pipelines/chomp/smoothness_cost_weight: 0.1
 * /move_group/planning_pipelines/chomp/start_state_max_bounds_error: 0.1
 * /move_group/planning_pipelines/chomp/use_pseudo_inverse: False
 * /move_group/planning_pipelines/chomp/use_stochastic_descent: True
 * /move_group/planning_pipelines/ompl/jiggle_fraction: 0.05
 * /move_group/planning_pipelines/ompl/panda_arm/longest_valid_segment_fraction: 0.005
 * /move_group/planning_pipelines/ompl/panda_arm/planner_configs: ['AnytimePathShor...
 * /move_group/planning_pipelines/ompl/panda_arm/projection_evaluator: joints(panda_join...
 * /move_group/planning_pipelines/ompl/panda_hand/planner_configs: ['AnytimePathShor...
 * /move_group/planning_pipelines/ompl/panda_manipulator/longest_valid_segment_fraction: 0.005
 * /move_group/planning_pipelines/ompl/panda_manipulator/planner_configs: ['AnytimePathShor...
 * /move_group/planning_pipelines/ompl/panda_manipulator/projection_evaluator: joints(panda_join...
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/hybridize: True
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/max_hybrid_paths: 24
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/num_planners: 4
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/planners: 
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/shortcut: True
 * /move_group/planning_pipelines/ompl/planner_configs/AnytimePathShortening/type: geometric::Anytim...
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/balanced: 0
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/cache_cc: 1
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/extended_fmt: 1
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/heuristics: 1
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/nearest_k: 1
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/num_samples: 1000
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/optimality: 1
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/radius_multiplier: 1.0
 * /move_group/planning_pipelines/ompl/planner_configs/BFMT/type: geometric::BFMT
 * /move_group/planning_pipelines/ompl/planner_configs/BKPIECE/border_fraction: 0.9
 * /move_group/planning_pipelines/ompl/planner_configs/BKPIECE/failed_expansion_score_factor: 0.5
 * /move_group/planning_pipelines/ompl/planner_configs/BKPIECE/min_valid_path_fraction: 0.5
 * /move_group/planning_pipelines/ompl/planner_configs/BKPIECE/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/BKPIECE/type: geometric::BKPIECE
 * /move_group/planning_pipelines/ompl/planner_configs/BiEST/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/BiEST/type: geometric::BiEST
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/cost_threshold: 1e300
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/frountier_node_ratio: 0.1
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/frountier_threshold: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/init_temperature: 100
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/temp_change_factor: 0.1
 * /move_group/planning_pipelines/ompl/planner_configs/BiTRRT/type: geometric::BiTRRT
 * /move_group/planning_pipelines/ompl/planner_configs/EST/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/EST/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/EST/type: geometric::EST
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/cache_cc: 1
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/extended_fmt: 1
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/heuristics: 0
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/nearest_k: 1
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/num_samples: 1000
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/radius_multiplier: 1.1
 * /move_group/planning_pipelines/ompl/planner_configs/FMT/type: geometric::FMT
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/border_fraction: 0.9
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/failed_expansion_score_factor: 0.5
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/min_valid_path_fraction: 0.5
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/KPIECE/type: geometric::KPIECE
 * /move_group/planning_pipelines/ompl/planner_configs/LBKPIECE/border_fraction: 0.9
 * /move_group/planning_pipelines/ompl/planner_configs/LBKPIECE/min_valid_path_fraction: 0.5
 * /move_group/planning_pipelines/ompl/planner_configs/LBKPIECE/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/LBKPIECE/type: geometric::LBKPIECE
 * /move_group/planning_pipelines/ompl/planner_configs/LBTRRT/epsilon: 0.4
 * /move_group/planning_pipelines/ompl/planner_configs/LBTRRT/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/LBTRRT/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/LBTRRT/type: geometric::LBTRRT
 * /move_group/planning_pipelines/ompl/planner_configs/LazyPRM/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/LazyPRM/type: geometric::LazyPRM
 * /move_group/planning_pipelines/ompl/planner_configs/LazyPRMstar/type: geometric::LazyPR...
 * /move_group/planning_pipelines/ompl/planner_configs/PDST/type: geometric::PDST
 * /move_group/planning_pipelines/ompl/planner_configs/PRM/max_nearest_neighbors: 10
 * /move_group/planning_pipelines/ompl/planner_configs/PRM/type: geometric::PRM
 * /move_group/planning_pipelines/ompl/planner_configs/PRMstar/type: geometric::PRMstar
 * /move_group/planning_pipelines/ompl/planner_configs/ProjEST/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/ProjEST/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/ProjEST/type: geometric::ProjEST
 * /move_group/planning_pipelines/ompl/planner_configs/RRT/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/RRT/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/RRT/type: geometric::RRT
 * /move_group/planning_pipelines/ompl/planner_configs/RRTConnect/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/RRTConnect/type: geometric::RRTCon...
 * /move_group/planning_pipelines/ompl/planner_configs/RRTstar/delay_collision_checking: 1
 * /move_group/planning_pipelines/ompl/planner_configs/RRTstar/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/RRTstar/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/RRTstar/type: geometric::RRTstar
 * /move_group/planning_pipelines/ompl/planner_configs/SBL/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/SBL/type: geometric::SBL
 * /move_group/planning_pipelines/ompl/planner_configs/SPARS/dense_delta_fraction: 0.001
 * /move_group/planning_pipelines/ompl/planner_configs/SPARS/max_failures: 1000
 * /move_group/planning_pipelines/ompl/planner_configs/SPARS/sparse_delta_fraction: 0.25
 * /move_group/planning_pipelines/ompl/planner_configs/SPARS/stretch_factor: 3.0
 * /move_group/planning_pipelines/ompl/planner_configs/SPARS/type: geometric::SPARS
 * /move_group/planning_pipelines/ompl/planner_configs/SPARStwo/dense_delta_fraction: 0.001
 * /move_group/planning_pipelines/ompl/planner_configs/SPARStwo/max_failures: 5000
 * /move_group/planning_pipelines/ompl/planner_configs/SPARStwo/sparse_delta_fraction: 0.25
 * /move_group/planning_pipelines/ompl/planner_configs/SPARStwo/stretch_factor: 3.0
 * /move_group/planning_pipelines/ompl/planner_configs/SPARStwo/type: geometric::SPARStwo
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/degree: 16
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/estimated_dimension: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/max_degree: 18
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/max_pts_per_leaf: 6
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/min_degree: 12
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/min_valid_path_fraction: 0.2
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/type: geometric::STRIDE
 * /move_group/planning_pipelines/ompl/planner_configs/STRIDE/use_projected_distance: 0
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/frountierNodeRatio: 0.1
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/frountier_threshold: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/goal_bias: 0.05
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/init_temperature: 10e-6
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/k_constant: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/max_states_failed: 10
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/min_temperature: 10e-10
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/range: 0.0
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/temp_change_factor: 2.0
 * /move_group/planning_pipelines/ompl/planner_configs/TRRT/type: geometric::TRRT
 * /move_group/planning_pipelines/ompl/planning_plugin: ompl_interface/OM...
 * /move_group/planning_pipelines/ompl/request_adapters: default_planner_r...
 * /move_group/planning_pipelines/ompl/start_state_max_bounds_error: 0.1
 * /move_group/planning_pipelines/pilz_industrial_motion_planner/capabilities: pilz_industrial_m...
 * /move_group/planning_pipelines/pilz_industrial_motion_planner/default_planner_config: PTP
 * /move_group/planning_pipelines/pilz_industrial_motion_planner/planning_plugin: pilz_industrial_m...
 * /move_group/planning_pipelines/pilz_industrial_motion_planner/request_adapters: 
 * /move_group/planning_pipelines/stomp/jiggle_fraction: 0.05
 * /move_group/planning_pipelines/stomp/manipulator/group_name: manipulator
 * /move_group/planning_pipelines/stomp/manipulator/optimization/control_cost_weight: 0.0
 * /move_group/planning_pipelines/stomp/manipulator/optimization/initialization_method: 1
 * /move_group/planning_pipelines/stomp/manipulator/optimization/max_rollouts: 30
 * /move_group/planning_pipelines/stomp/manipulator/optimization/num_iterations: 40
 * /move_group/planning_pipelines/stomp/manipulator/optimization/num_iterations_after_valid: 0
 * /move_group/planning_pipelines/stomp/manipulator/optimization/num_rollouts: 30
 * /move_group/planning_pipelines/stomp/manipulator/optimization/num_timesteps: 60
 * /move_group/planning_pipelines/stomp/manipulator/task/cost_functions: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/manipulator/task/noise_generator: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/manipulator/task/noisy_filters: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/manipulator/task/update_filters: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/panda_arm/group_name: panda_arm
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/control_cost_weight: 0.0
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/initialization_method: 1
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/max_rollouts: 30
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/num_iterations: 40
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/num_iterations_after_valid: 0
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/num_rollouts: 30
 * /move_group/planning_pipelines/stomp/panda_arm/optimization/num_timesteps: 60
 * /move_group/planning_pipelines/stomp/panda_arm/task/cost_functions: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/panda_arm/task/noise_generator: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/panda_arm/task/noisy_filters: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/panda_arm/task/update_filters: [{'class': 'stomp...
 * /move_group/planning_pipelines/stomp/planning_plugin: stomp_moveit/Stom...
 * /move_group/planning_pipelines/stomp/request_adapters: default_planner_r...
 * /move_group/planning_pipelines/stomp/start_state_max_bounds_error: 0.1
 * /move_group/planning_scene_monitor/publish_geometry_updates: True
 * /move_group/planning_scene_monitor/publish_planning_scene: True
 * /move_group/planning_scene_monitor/publish_state_updates: True
 * /move_group/planning_scene_monitor/publish_transforms_updates: True
 * /move_group/sense_for_plan/max_safe_path_cost: 1
 * /move_group/trajectory_execution/allowed_execution_duration_scaling: 1.2
 * /move_group/trajectory_execution/allowed_goal_duration_margin: 0.5
 * /move_group/trajectory_execution/allowed_start_tolerance: 0.01
 * /robot_description: <?xml version="1....
 * /robot_description_kinematics/panda_arm/kinematics_solver: kdl_kinematics_pl...
 * /robot_description_kinematics/panda_arm/kinematics_solver_search_resolution: 0.005
 * /robot_description_kinematics/panda_arm/kinematics_solver_timeout: 0.05
 * /robot_description_kinematics/panda_manipulator/kinematics_solver: kdl_kinematics_pl...
 * /robot_description_kinematics/panda_manipulator/kinematics_solver_search_resolution: 0.005
 * /robot_description_kinematics/panda_manipulator/kinematics_solver_timeout: 0.05
 * /robot_description_planning/cartesian_limits/max_rot_vel: 1.57
 * /robot_description_planning/cartesian_limits/max_trans_acc: 2.25
 * /robot_description_planning/cartesian_limits/max_trans_dec: -5
 * /robot_description_planning/cartesian_limits/max_trans_vel: 1
 * /robot_description_planning/default_acceleration_scaling_factor: 0.1
 * /robot_description_planning/default_velocity_scaling_factor: 0.1
 * /robot_description_planning/joint_limits/panda_finger_joint1/has_acceleration_limits: False
 * /robot_description_planning/joint_limits/panda_finger_joint1/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_finger_joint1/max_acceleration: 0
 * /robot_description_planning/joint_limits/panda_finger_joint1/max_velocity: 0.1
 * /robot_description_planning/joint_limits/panda_finger_joint2/has_acceleration_limits: False
 * /robot_description_planning/joint_limits/panda_finger_joint2/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_finger_joint2/max_acceleration: 0
 * /robot_description_planning/joint_limits/panda_finger_joint2/max_velocity: 0.1
 * /robot_description_planning/joint_limits/panda_joint1/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint1/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint1/max_acceleration: 3.75
 * /robot_description_planning/joint_limits/panda_joint1/max_velocity: 2.175
 * /robot_description_planning/joint_limits/panda_joint2/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint2/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint2/max_acceleration: 1.875
 * /robot_description_planning/joint_limits/panda_joint2/max_velocity: 2.175
 * /robot_description_planning/joint_limits/panda_joint3/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint3/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint3/max_acceleration: 2.5
 * /robot_description_planning/joint_limits/panda_joint3/max_velocity: 2.175
 * /robot_description_planning/joint_limits/panda_joint4/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint4/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint4/max_acceleration: 3.125
 * /robot_description_planning/joint_limits/panda_joint4/max_velocity: 2.175
 * /robot_description_planning/joint_limits/panda_joint5/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint5/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint5/max_acceleration: 3.75
 * /robot_description_planning/joint_limits/panda_joint5/max_velocity: 2.61
 * /robot_description_planning/joint_limits/panda_joint6/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint6/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint6/max_acceleration: 5
 * /robot_description_planning/joint_limits/panda_joint6/max_velocity: 2.61
 * /robot_description_planning/joint_limits/panda_joint7/has_acceleration_limits: True
 * /robot_description_planning/joint_limits/panda_joint7/has_velocity_limits: True
 * /robot_description_planning/joint_limits/panda_joint7/max_acceleration: 5
 * /robot_description_planning/joint_limits/panda_joint7/max_velocity: 2.61
 * /robot_description_semantic: <?xml version="1....
 * /rosdistro: noetic
 * /rosversion: 1.16.0

NODES
  /
    joint_state_publisher (joint_state_publisher/joint_state_publisher)
    move_group (moveit_ros_move_group/move_group)
    robot_state_publisher (robot_state_publisher/robot_state_publisher)
    rviz_vm20test_198817_1327242741778448814 (rviz/rviz)
    virtual_joint_broadcaster_0 (tf2_ros/static_transform_publisher)

auto-starting new master
process[master]: started with pid [198829]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 6ebbbbb0-2ed2-11ee-8754-c783d253aba5
process[rosout-1]: started with pid [198840]
started core service [/rosout]
process[virtual_joint_broadcaster_0-2]: started with pid [198847]
process[joint_state_publisher-3]: started with pid [198848]
process[robot_state_publisher-4]: started with pid [198849]
process[move_group-5]: started with pid [198854]
process[rviz_vm20test_198817_1327242741778448814-6]: started with pid [198856]
[ INFO] [1690719183.746446286]: Loading robot model 'panda'...
[ INFO] [1690719183.800026861]: rviz version 1.14.20
[ INFO] [1690719183.800049556]: compiled against Qt version 5.12.8
[ INFO] [1690719183.800060624]: compiled against OGRE version 1.9.0 (Ghadamon)
[ INFO] [1690719183.805136327]: Forcing OpenGl version 0.
[ INFO] [1690719183.822394142]: Publishing maintained planning scene on 'monitored_planning_scene'
[ INFO] [1690719183.823514142]: Listening to 'joint_states' for joint states
[ INFO] [1690719183.824915870]: Listening to '/attached_collision_object' for attached collision objects
[ INFO] [1690719183.824933307]: Starting planning scene monitor
[ INFO] [1690719183.825466969]: Listening to '/planning_scene'
[ INFO] [1690719183.825480529]: Starting world geometry update monitor for collision objects, attached objects, octomap updates.
[ INFO] [1690719183.826024487]: Listening to '/collision_object'
[ INFO] [1690719183.826556475]: Listening to '/planning_scene_world' for planning scene world geometry
[ INFO] [1690719183.826843080]: No 3D sensor plugin(s) defined for octomap updates
[ INFO] [1690719183.839655753]: Loading planning pipeline 'chomp'
[ INFO] [1690719183.851948119]: Using planning interface 'CHOMP'
[ INFO] [1690719183.853675289]: Param 'default_workspace_bounds' was not set. Using default value: 10
[ INFO] [1690719183.853800990]: Param 'start_state_max_bounds_error' was set to 0.1
[ INFO] [1690719183.853896816]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1690719183.854003232]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1690719183.854097034]: Param 'jiggle_fraction' was set to 0.05
[ INFO] [1690719183.854190224]: Param 'max_sampling_attempts' was not set. Using default value: 100
[ INFO] [1690719183.854238240]: Using planning request adapter 'Add Time Parameterization'
[ INFO] [1690719183.854257332]: Using planning request adapter 'Resolve constraint frames to robot links'
[ INFO] [1690719183.854270522]: Using planning request adapter 'Fix Workspace Bounds'
[ INFO] [1690719183.854283723]: Using planning request adapter 'Fix Start State Bounds'
[ INFO] [1690719183.854296107]: Using planning request adapter 'Fix Start State In Collision'
[ INFO] [1690719183.854307511]: Using planning request adapter 'Fix Start State Path Constraints'
[ INFO] [1690719183.854816679]: Loading planning pipeline 'ompl'
[ INFO] [1690719183.883599612]: Using planning interface 'OMPL'
[ INFO] [1690719183.884743724]: Param 'default_workspace_bounds' was not set. Using default value: 10
[ INFO] [1690719183.884910632]: Param 'start_state_max_bounds_error' was set to 0.1
[ INFO] [1690719183.885024804]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1690719183.885149500]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1690719183.885256408]: Param 'jiggle_fraction' was set to 0.05
[ INFO] [1690719183.885360536]: Param 'max_sampling_attempts' was not set. Using default value: 100
[ INFO] [1690719183.885397547]: Using planning request adapter 'Add Time Parameterization'
[ INFO] [1690719183.885411708]: Using planning request adapter 'Resolve constraint frames to robot links'
[ INFO] [1690719183.885424744]: Using planning request adapter 'Fix Workspace Bounds'
[ INFO] [1690719183.885437211]: Using planning request adapter 'Fix Start State Bounds'
[ INFO] [1690719183.885449447]: Using planning request adapter 'Fix Start State In Collision'
[ INFO] [1690719183.885462293]: Using planning request adapter 'Fix Start State Path Constraints'
[ INFO] [1690719183.885519395]: Loading planning pipeline 'pilz_industrial_motion_planner'
[ INFO] [1690719183.887194764]: Reading limits from namespace /robot_description_planning
[ INFO] [1690719183.893606588]: Available plugins: pilz_industrial_motion_planner::PlanningContextLoaderCIRC pilz_industrial_motion_planner::PlanningContextLoaderLIN pilz_industrial_motion_planner::PlanningContextLoaderPTP 
[ INFO] [1690719183.893635070]: About to load: pilz_industrial_motion_planner::PlanningContextLoaderCIRC
[ INFO] [1690719183.894637895]: Registered Algorithm [CIRC]
[ INFO] [1690719183.894677585]: About to load: pilz_industrial_motion_planner::PlanningContextLoaderLIN
[ INFO] [1690719183.895415149]: Registered Algorithm [LIN]
[ INFO] [1690719183.895437651]: About to load: pilz_industrial_motion_planner::PlanningContextLoaderPTP
[ INFO] [1690719183.896127642]: Registered Algorithm [PTP]
[ INFO] [1690719183.896151210]: Using planning interface 'Pilz Industrial Motion Planner'
[ INFO] [1690719183.896200504]: Loading planning pipeline 'stomp'
[ERROR] [1690719183.898887624]: The 'stomp' configuration parameter was not found
terminate called after throwing an instance of 'std::runtime_error'
  what():  Unable to initialize planning plugin
[ INFO] [1690719183.901128689]: Stereo is NOT SUPPORTED
[ INFO] [1690719183.901169711]: OpenGL device: llvmpipe (LLVM 12.0.0, 256 bits)
[ INFO] [1690719183.901182230]: OpenGl version: 3.1 (GLSL 1.4).
[move_group-5] process has died [pid 198854, exit code -6, cmd /home/test/ws_moveit/devel/lib/moveit_ros_move_group/move_group --debug __name:=move_group __log:=/home/test/.ros/log/6ebbbbb0-2ed2-11ee-8754-c783d253aba5/move_group-5.log].
log file: /home/test/.ros/log/6ebbbbb0-2ed2-11ee-8754-c783d253aba5/move_group-5*.log
[ INFO] [1690719187.087914988]: Loading robot model 'panda'...
[ INFO] [1690719187.180045636]: Starting planning scene monitor
[ INFO] [1690719187.181582743]: Listening to '/move_group/monitored_planning_scene'
[ INFO] [1690719187.353536355]: waitForService: Service [/get_planning_scene] has not been advertised, waiting...
[ INFO] [1690719192.357534078]: Failed to call service get_planning_scene, have you launched move_group or called psm.providePlanningSceneService()?
[ INFO] [1690719192.358127379]: Constructing new MoveGroup connection for group 'panda_arm' in namespace ''
[ERROR] [1690719222.365363219]: Unable to connect to move_group action server 'move_group' within allotted time (30s)
[ INFO] [1690719222.366715804]: Constructing new MoveGroup connection for group 'panda_arm' in namespace ''
[ERROR] [1690719252.370154951]: Unable to connect to move_group action server 'move_group' within allotted time (3
```

This fix is based on https://github.com/ros-planning/panda_moveit_config/issues/131
