### PR TITLE
chore: fix cmake min version deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(panda_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5)
 project(panda_moveit_config)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Not sure if this is desirable given back-compatibility, but this pull request ensures that the cmake minimum version < 3.5 deprecation warning is no longer thrown:

```bash
Warnings   << panda_moveit_config:cmake /home/ricks/development/work/pmc_ws/logs/panda_moveit_config/build.cmake.000.log                                                                                   
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):                                                                                                                                    
  Compatibility with CMake < 3.5 will be removed from a future version of                                                                                                                                  
  CMake.                                                                                                                                                                                                   
                                                                                                                                                                                                           
  Update the VERSION argument <min> value or use a ...<max> suffix to tell                                                                                                                                 
  CMake that the project does not need compatibility with older versions. 
```